### PR TITLE
Update federation.rst: Terminology fix.

### DIFF
--- a/source/federation.rst
+++ b/source/federation.rst
@@ -330,7 +330,7 @@ defining v0.2 of the format is shown below:
 | IPVersion                 | ``byte``         | No   | 4 or 6                          |                                       |
 +---------------------------+------------------+------+---------------------------------+---------------------------------------+
 | IPCount                   | ``int(11)``      | No   | The number of IP addresses of   |                                       |
-|                           |                  |      | IPType this user currently      |                                       |
+|                           |                  |      | IPVersion this user currently   |                                       |
 |                           |                  |      | assigned to them                |                                       |
 +---------------------------+------------------+------+---------------------------------+---------------------------------------+
 


### PR DESCRIPTION
# Summary 

Changing IPType to IPVersion. Attribute name changed in specification but not in other attributes' description.

<!-- Describe in plain English what this PR does -->

----
<!-- Add the related issue here, e.g. #6 -->
**Related issue :**

N/A: ad-hoc fix